### PR TITLE
Use node 6.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Martin Lazarov <martin@lazarov.bg>
 
 RUN yum -y update; yum -y install epel-release; yum clean all
 
-RUN yum install -y https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodejs-6.9.1-1nodesource.el7.centos.x86_64.rpm; yum clean all
+RUN yum install -y https://rpm.nodesource.com/pub_6.x/el/7/x86_64/nodejs-6.11.1-1nodesource.el7.centos.x86_64.rpm; yum clean all
 
 RUN npm install --global yarn
 


### PR DESCRIPTION
Includes a fix for CVE-2017-1000381: The c-ares function
`ares_parse_naptr_reply()`, which is used for parsing NAPTR responses,
could be triggered to read memory outside of the given input buffer if
the passed in DNS response packet was crafted in a particular way.